### PR TITLE
fix(ci): Stop silencing test and security scan failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,11 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests/ -v --tb=short || echo "No tests yet"
+          if find tests -name 'test_*.py' -o -name '*_test.py' 2>/dev/null | grep -q .; then
+            pytest tests/ -v --tb=short
+          else
+            echo "No test files found - skipping"
+          fi
 
   security:
     runs-on: ubuntu-latest
@@ -60,4 +64,4 @@ jobs:
 
       - name: Security scan with bandit
         run: |
-          bandit -r src/aiana -ll || true
+          bandit -r src/aiana --severity-level medium


### PR DESCRIPTION
## Summary
- Test step now properly checks for test files before running pytest, failing if tests exist and fail
- Security scan (bandit) now fails on medium+ severity findings instead of silently passing

## Changes
- Replaced `pytest ... || echo "No tests yet"` with conditional check for test files
- Replaced `bandit ... || true` with `bandit --severity-level medium` to fail on real issues

## Test plan
- [ ] Verify CI passes when no tests exist
- [ ] Verify CI fails when tests fail
- [ ] Verify CI fails on medium/high security findings

🐰 Found by [CodeRabbit](https://coderabbit.ai) review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CI now surfaces real failures: test jobs run only when test files exist and fail on test errors; Bandit now fails on medium+ severity findings.

- **Bug Fixes**
  - Tests: conditionally run pytest if test files are found; otherwise skip with a message.
  - Security: remove silent pass; run Bandit with --severity-level medium to fail on meaningful issues.

<sup>Written for commit d4ff61efb62cdb7050985d794206a779bee16b08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline with conditional test execution to optimize workflow performance
  * Enhanced security scanning with updated severity threshold handling for better vulnerability detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->