### PR TITLE
fix: make aiana installable and compatible with qdrant-client >= 1.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ aiana-mcp = "aiana.mcp.server:main"
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=">=9.0.3",
+    "pytest>=9.0.3",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.1.0",
     "pytest-mock>=3.12.0",
@@ -66,7 +66,7 @@ dev = [
     "safety>=3.0.0",
 ]
 encryption = [
-    "cryptography>=">=46.0.6",
+    "cryptography>=46.0.6",
 ]
 vector = [
     "qdrant-client>=1.7.0",

--- a/src/aiana/storage/qdrant.py
+++ b/src/aiana/storage/qdrant.py
@@ -118,7 +118,7 @@ class QdrantStorage:
         limit: int = 10,
         project: Optional[str] = None,
         memory_type: Optional[str] = None,
-        min_score: float = 0.5,
+        min_score: float = 0.3,
     ) -> list[dict]:
         """Search memories semantically.
 

--- a/src/aiana/storage/qdrant.py
+++ b/src/aiana/storage/qdrant.py
@@ -156,13 +156,15 @@ class QdrantStorage:
 
         search_filter = Filter(must=conditions) if conditions else None
 
-        results = self.client.search(
+        # qdrant-client >= 1.12 removed Client.search() in favor of query_points().
+        results = self.client.query_points(
             collection_name=COLLECTION_NAME,
-            query_vector=query_vector,
+            query=query_vector,
             limit=limit,
             query_filter=search_filter,
             score_threshold=min_score,
-        )
+            with_payload=True,
+        ).points
 
         return [
             {


### PR DESCRIPTION
## Summary

Three fixes so aiana's full (Qdrant-backed semantic) setup installs and actually returns results. Verified end-to-end on a fully local stack (local Qdrant + local `sentence-transformers` embedder + a local MLX model via OpenCode).

## Bug 1 — `pyproject.toml` is unparseable (`pip install` fails)

Two optional-dependency entries had malformed version specifiers (doubled operator + stray quote):

```toml
"pytest>=">=9.0.3"          # -> "pytest>=9.0.3"
"cryptography>=">=46.0.6"   # -> "cryptography>=46.0.6"
```

Invalid TOML (`tomllib.TOMLDecodeError: Unclosed array (at line 59)`), so the package **cannot be installed at all**.

## Bug 2 — `QdrantStorage.search()` calls a removed client method

`qdrant-client >= 1.12` removed `QdrantClient.search()` in favor of `QdrantClient.query_points()`. The old call raised `AttributeError`, which `_memory_search()`'s `try/except` **silently swallowed** — so semantic search just returned nothing.

```python
results = self.client.query_points(
    collection_name=COLLECTION_NAME, query=query_vector, limit=limit,
    query_filter=search_filter, score_threshold=min_score, with_payload=True,
).points
```

## Bug 3 — default `min_score` too strict (empty results for relevant queries)

With `all-MiniLM-L6-v2`, clearly-relevant memories score ~0.40–0.48 for natural-language queries, while irrelevant content scores < 0.1. Measured example:

| query | top match | score |
|---|---|---|
| "what model does the MLX lab use" | "The MLX lab runs Qwen3.5-4B-4bit…" | **0.475** |
| "MLX lab model" | (same) | **0.404** |

The old `min_score=0.5` floor dropped these relevant top hits, so `memory_search` returned nothing for reasonable queries. Lowered the default to `0.3`, which surfaces the correct top result while still filtering noise.

## Verification

Python 3.13, `qdrant-client 1.18.0`, local Qdrant + `all-MiniLM-L6-v2`:

- `pip install -e .` succeeds.
- `memory_add` stores a 384-dim vector in `aiana_memories`.
- `memory_search` retrieves it via `query_points` and returns relevant hits at the new threshold.
- Driven live: a local MLX model (Qwen3.5-4B) via OpenCode calls `aiana_memory_add` then `aiana_memory_search`; both requests are visible in the Qdrant access log (`PUT .../points`, `POST .../points/query`).
- Backends init: SQLite + Redis + Qdrant + embedder (mem0 cleanly falls back with no LLM key configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)