### PR TITLE
feat: optional MLX embedder backend (torch-free, Apple-silicon native)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,11 @@ vector = [
 mcp = [
     "mcp>=1.0.0",
 ]
+mlx = [
+    "mlx-embeddings>=0.1.0",
+]
 all = [
-    "aiana[encryption,vector,mcp]",
+    "aiana[encryption,vector,mcp,mlx]",
 ]
 
 [build-system]

--- a/src/aiana/embeddings/__init__.py
+++ b/src/aiana/embeddings/__init__.py
@@ -1,5 +1,6 @@
 """Embeddings module for text-to-vector conversion."""
 
 from aiana.embeddings.embedder import Embedder, get_embedder
+from aiana.embeddings.mlx_embedder import MLXEmbedder
 
-__all__ = ["Embedder", "get_embedder"]
+__all__ = ["Embedder", "get_embedder", "MLXEmbedder"]

--- a/src/aiana/embeddings/embedder.py
+++ b/src/aiana/embeddings/embedder.py
@@ -166,12 +166,30 @@ def get_embedder(
         model_name: Model to use. If different from current, creates new.
         force_new: Force creation of new instance.
 
+    The backend is chosen by the ``AIANA_EMBEDDER_BACKEND`` environment variable:
+    ``sentence-transformers`` (default) or ``mlx`` (torch-free, Apple-silicon
+    native via mlx-embeddings; requires ``pip install 'aiana[mlx]'``).
+
     Returns:
-        Embedder instance.
+        An embedder exposing ``.embed()`` and ``.dimension``.
     """
     global _embedder
 
-    if force_new or _embedder is None:
+    backend = os.environ.get("AIANA_EMBEDDER_BACKEND", "sentence-transformers").lower()
+
+    if backend in ("mlx", "mlx-embeddings"):
+        from aiana.embeddings.mlx_embedder import MLXEmbedder
+
+        if (
+            force_new
+            or _embedder is None
+            or not isinstance(_embedder, MLXEmbedder)
+            or (model_name and _embedder.model_name != model_name)
+        ):
+            _embedder = MLXEmbedder(model_name=model_name)
+        return _embedder
+
+    if force_new or _embedder is None or not isinstance(_embedder, Embedder):
         _embedder = Embedder(model_name=model_name)
     elif model_name and _embedder.model_name != model_name:
         _embedder = Embedder(model_name=model_name)

--- a/src/aiana/embeddings/mlx_embedder.py
+++ b/src/aiana/embeddings/mlx_embedder.py
@@ -1,0 +1,70 @@
+"""MLX-native embedder backend (optional, torch-free).
+
+Mirrors the :class:`~aiana.embeddings.embedder.Embedder` interface but runs on
+MLX via ``mlx-embeddings``, so aiana can embed on Apple silicon without pulling
+in PyTorch. Defaults to ``all-MiniLM-L6-v2`` (384-dim) to stay compatible with
+the existing 384-dim ``aiana_memories`` collection and any vectors already
+written by the sentence-transformers backend.
+
+Enable with::
+
+    pip install "aiana[mlx]"
+    export AIANA_EMBEDDER_BACKEND=mlx
+"""
+
+import os
+from typing import Optional, Union
+
+try:
+    import mlx.core as mx
+    from mlx_embeddings import generate, load
+
+    MLX_EMBEDDINGS_AVAILABLE = True
+except ImportError:
+    MLX_EMBEDDINGS_AVAILABLE = False
+
+# Same model family as the sentence-transformers default, so embeddings live in
+# the same 384-dim vector space (existing memories remain searchable).
+DEFAULT_MLX_MODEL = "mlx-community/all-MiniLM-L6-v2-bf16"
+
+
+class MLXEmbedder:
+    """Text-to-vector embedder backed by MLX (no PyTorch)."""
+
+    def __init__(self, model_name: Optional[str] = None):
+        if not MLX_EMBEDDINGS_AVAILABLE:
+            raise ImportError(
+                "mlx-embeddings not installed. Install with: pip install 'aiana[mlx]'"
+            )
+        self.model_name = model_name or os.environ.get(
+            "AIANA_EMBEDDING_MODEL", DEFAULT_MLX_MODEL
+        )
+        self.model, self.tokenizer = load(self.model_name)
+        probe = generate(self.model, self.tokenizer, texts=["probe"])
+        self._dimension = int(probe.text_embeds.shape[-1])
+
+    @property
+    def dimension(self) -> int:
+        """Embedding vector dimension."""
+        return self._dimension
+
+    def embed(
+        self, text: Union[str, list[str]]
+    ) -> Union[list[float], list[list[float]]]:
+        """Embed text into L2-normalized vectors (dot product == cosine)."""
+        single = isinstance(text, str)
+        texts = [text] if single else list(text)
+
+        out = generate(self.model, self.tokenizer, texts=texts)
+        embeddings = out.text_embeds
+        norms = mx.linalg.norm(embeddings, axis=1, keepdims=True)
+        embeddings = embeddings / mx.maximum(norms, 1e-12)
+        mx.eval(embeddings)
+
+        vectors = embeddings.tolist()
+        return vectors[0] if single else vectors
+
+    def similarity(self, text1: str, text2: str) -> float:
+        """Cosine similarity between two texts."""
+        v1, v2 = self.embed([text1, text2])
+        return float(sum(a * b for a, b in zip(v1, v2)))


### PR DESCRIPTION
## Summary

Adds an **optional MLX embedding backend** so aiana can embed on Apple silicon **without PyTorch**, selectable via `AIANA_EMBEDDER_BACKEND=mlx`. Sentence-transformers stays the default — **no behavior change unless opted in.**

Motivation: running the sentence-transformers/torch embedder alongside a local LLM is heavy (it was the dependency that OOM'd a 16 GB M1 in practice). An MLX embedder shares the same unified-memory runtime as MLX-served models, so the embedding layer becomes lighter and fully Apple-silicon-native.

## Changes

- **`embeddings/mlx_embedder.py`** — new `MLXEmbedder` mirroring the `Embedder` interface (`embed`, `dimension`, `similarity`), running on `mlx-embeddings`. Optional import with a clear install hint; defaults to **`all-MiniLM-L6-v2` (384-dim)** — the *same model family and vector space* as the sentence-transformers default, so **existing `aiana_memories` vectors stay searchable** (no migration).
- **`embeddings/embedder.py`** — `get_embedder()` selects the backend from `AIANA_EMBEDDER_BACKEND` (`sentence-transformers` default, or `mlx`).
- **`pyproject.toml`** — new optional extra `mlx` (`mlx-embeddings`), added to `all`.

## Usage

```bash
pip install "aiana[mlx]"
export AIANA_EMBEDDER_BACKEND=mlx
```

## Verification

On Python 3.13 / Apple silicon:

```
AIANA_EMBEDDER_BACKEND=mlx → get_embedder() -> MLXEmbedder
model: mlx-community/all-MiniLM-L6-v2-bf16
dimension: 384 | embedding L2-norm: 1.0
semantic separation (related > unrelated): True
```

## Notes

- Default backend and behavior are unchanged; this is purely additive/opt-in.
- Switching an existing deployment from one model family to another implies re-embedding; defaulting the MLX backend to `all-MiniLM-L6-v2` avoids that for the common case.
- Independent of #17 (the install/qdrant-client-compat fixes); this branch is cut from `main` and stacks cleanly with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)